### PR TITLE
[DM-5977] Create and deploy Beats to enable Logstash and Elasticsearch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+before_script:
+  - echo localhost > inventory
+  - ansible-galaxy install --role-file requirements.yml
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ansible-beats
 ====================
 
-[![Build Status](https://travis-ci.org/jmatt/ansible-beats.svg?branch=master)](https://travis-ci.org/jmatt/ansible-beats)
+[![Build Status](https://travis-ci.org/lsst-sqre/ansible-beats.svg?branch=master)](https://travis-ci.org/lsst-sqre/ansible-beats)
 
 Install and configure Elastic [beats](https://www.elastic.co/products/beats) v5 for LSST SQuaRE infrastructure.
 
@@ -10,7 +10,7 @@ Example Playbook
 
     - hosts: servers
       roles:
-         - { role: jmatt.beats }
+         - { role: lsst-sqre.beats }
 
 Variables
 ---------

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+ansible-beats
+====================
+
+[![Build Status](https://travis-ci.org/jmatt/ansible-beats.svg?branch=master)](https://travis-ci.org/jmatt/ansible-beats)
+
+Install and configure Elastic [beats](https://www.elastic.co/products/beats) v5 for LSST SQuaRE infrastructure.
+
+Example Playbook
+----------------
+
+    - hosts: servers
+      roles:
+         - { role: jmatt.beats }
+
+Variables
+---------
+
+For complete documentation on configuration options see the [topbeat](https://www.elastic.co/guide/en/beats/topbeat/master/topbeat-getting-started.html), [filebeat](https://www.elastic.co/guide/en/beats/filebeat/master/index.html) and [packetbeat](https://www.elastic.co/guide/en/beats/packetbeat/master/index.html) documentation.
+
+`beats_package_name` *(default "topbeat")* The package name of the beat. Valid options are "topbeat", "filebeat" or "packetbeat".
+
+`beats_install` *(default true)* Whether to install the beat.
+
+`beats_config` *(default "")* The yaml configuration for the beat. If undefined by the user, no configuration will be applied.
+
+`beats_geoip` *(default false)* Wether to install [geoip](https://dev.maxmind.com/geoip/legacy/) for use by the beat.
+
+Acknowledgements
+----------------
+
+This role is based on [Jonathan D Strootman's](https://github.com/strootman) Ansible Galaxy role [`cyverse.beats`](https://galaxy.ansible.com/cyverse/beats/). It is a more complete implementation and less opinionated than this role. But it doesn't support v5 or follow the variable naming convention my roles follow. Thus this new role.
+
+I'd highly recommend [`cyverse.beats`](https://galaxy.ansible.com/cyverse/beats/). A big thanks to Strootman and Cyverse for their great roles.
+
+License
+-------
+
+The MIT License. See the [LICENSE file](https://github.com/lsst-sqre/ansible-beats/blob/master/LICENSE).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# defaults file for beats
+beats_package_name: topbeat
+beats_install: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+
+- name: restart beat
+  service:
+    name: "{{ beats_package_name }}"
+    state: restarted
+
+- name: enable beat
+  service:
+    name: "{{ beats_package_name }}"
+    enabled: true

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,35 @@
+galaxy_info:
+  author: J. Matt Peterson
+  description: Elastic beats v 5.0 for LSST SQuaRE.
+  company: LSST SQuaRE
+  issue_tracker_url: https://github.com/lsst-sqre/ansible-beats/issues
+  license: MIT
+  min_ansible_version: 2.1
+  platforms:
+  - name: EL
+    versions:
+      - 7
+  - name: Ubuntu
+    versions:
+      - trusty
+      - xenial
+  #- name: Debian
+  #  versions:
+  #  - all
+  #  - etch
+  #  - jessie
+  #  - lenny
+  #  - squeeze
+  #  - wheezy
+  galaxy_tags:
+    - centos
+    - beats
+    - elastic
+    - filebeat
+    - packetbeat
+    - system
+    - topbeat
+    - ubuntu
+dependencies:
+  - role: cyverse.geoip
+    when: beats_geoip | default(false)

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,1 @@
+- src: cyverse.geoip

--- a/tasks/check.yml
+++ b/tasks/check.yml
@@ -1,0 +1,7 @@
+---
+# Check beats variables and host.
+
+- name: Check if beats_package_name ({{ beats_package_name }}) is supported.
+  fail:
+    msg: "beats_package_name ({{ beats_package_name }}) is not supported."
+  when: beats_package_name not in beats_supported_package_names

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -1,0 +1,8 @@
+---
+# Configure beats package.
+
+- name: "Configure {{ beats_package_name }}."
+  template:
+    src: beats.yml.j2
+    dest: "/etc//{{ beats_package_name }}/{{ beats_package_name }}.yml"
+  notify: restart beat

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,0 +1,8 @@
+---
+# Install beats package on debian based distributions.
+
+- name: Install {{ beats_package_name }} deb package.
+  apt: deb="https://download.elastic.co/beats/{{ beats_package_name }}/{{ beats_package_name }}_5.0.0-alpha2_amd64.deb" state=present
+  notify:
+    - enable beat
+    - restart beat

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+# tasks file for beats
+
+- include: check.yml
+
+- block:
+  - include: redhat.yml
+    when: ansible_os_family == "RedHat"
+  - include: debian.yml
+    when: ansible_os_family == "Debian"
+  when: beats_install
+
+- include: config.yml
+  when: beats_config != ""

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,0 +1,8 @@
+---
+# Install Beats package on redhat based distributions.
+
+- name: Install {{ beats_package_name }} rpm package.
+  yum: name="https://download.elastic.co/beats/{{ beats_package_name }}/{{ beats_package_name }}-5.0.0-alpha2-x86_64.rpm" state=present
+  notify:
+    - enable beat
+    - restart beat

--- a/templates/beats.yml.j2
+++ b/templates/beats.yml.j2
@@ -1,0 +1,3 @@
+## {{ ansible_managed }}
+---
+{{ beats_config }}

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - ansible-beats

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,10 @@
+---
+# vars file for beats
+
+beats_supported_package_names:
+  - topbeat
+  - filebeat
+  - packetbeat
+
+beats_config: "" # Allows beats_config to be defined inline instead of
+                 # in a variable block.


### PR DESCRIPTION
Create and deploy [Elastic Beats](https://www.elastic.co/products/beats) to support the ansible-elk playbook (deploy) for LSST SQuaRE infrastructure.
- [x] Install {topbeat filebeat packetbeat} v5 on Ubuntu 14.04, 16.04 or CentOS 7 using the deb or rpm package.
- [x] Update the configuration for the beat.
- [x] Create the appropriate service through the package.
- [x] Install [geoip](https://dev.maxmind.com/geoip/legacy/) for use with filebeats (or Logstash).
- [x] Verify syntax using travis.ci.
- [x] Available as Ansible Galaxy role `jmatt.beats`. After PR is accepted and Ansible Galaxy is updated it'll be available as `lsst-sqre.beats`.
